### PR TITLE
Turn into a generic news api

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,11 +1,12 @@
 import './endpoint.dart';
 
 class NewsapiClient {
-  NewsapiClient(this.apiKey) : assert(apiKey != null && apiKey.isNotEmpty);
+  NewsapiClient(this.apiKey, {this.baseUrl = 'https://newsapi.org/v2/'}) : assert(apiKey != null && apiKey.isNotEmpty && baseUrl != null && baseUrl.isNotEmpty);
 
   final String apiKey;
+  final String baseUrl;
 
   Future<Map<String, dynamic>> request(Endpoint endpoint) {
-    return endpoint.request(apiKey);
+    return endpoint.request(apiKey, baseUrl);
   }
 }

--- a/lib/src/endpoint.dart
+++ b/lib/src/endpoint.dart
@@ -8,10 +8,10 @@ abstract class Endpoint {
   Map<String, dynamic> get parameters;
   final Client client = Client();
 
-  Future<Map<String, dynamic>> request(String apiKey) async {
+  Future<Map<String, dynamic>> request(String apiKey, String baseUrl) async {
     final String encodedParameters =
         parameters != null ? encodeParameters(parameters) : null;
-    final String endpointUrl = buildUrl(url, parameters: encodedParameters);
+    final String endpointUrl = buildUrl(baseUrl, url, parameters: encodedParameters);
     final response = await client.get(
       endpointUrl,
       headers: {'X-Api-Key': apiKey},

--- a/lib/src/util/build_url.dart
+++ b/lib/src/util/build_url.dart
@@ -1,5 +1,5 @@
-String buildUrl(String endpointUrl, {String parameters = null}) {
-  return 'https://newsapi.org/v2/' +
+String buildUrl(String baseUrl, String endpointUrl, {String parameters = null}) {
+  return baseUrl +
       endpointUrl +
       '?' +
       (parameters != null ? parameters : '');


### PR DESCRIPTION
Hello Salby,  
First of all thanks for the work on this and on Novum, really nice app!

So we were looking into using an API for our news service, and we would like to make the extension more generic. In concept, it will still work as before, but it will be extendable.

Are you open to this PR and others from similar nature?